### PR TITLE
Update ThinkPHP/Common/functions.php

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -648,7 +648,7 @@ function cookie($name, $value='', $option=null) {
         'domain'    =>  C('COOKIE_DOMAIN'), // cookie 有效域名
     );
     // 参数设置(会覆盖黙认设置)
-    if (!empty($option)) {
+    if (!is_null($option)) {
         if (is_numeric($option))
             $option = array('expire' => $option);
         elseif (is_string($option))


### PR DESCRIPTION
修复当$option为0的时候判断为空，不能快捷设置cookie的过期时间为0，改为通过is_null来判断参数$option
