### PR TITLE
 模板解析错误

### DIFF
--- a/ThinkPHP/Lib/Template/ThinkTemplate.class.php
+++ b/ThinkPHP/Lib/Template/ThinkTemplate.class.php
@@ -439,8 +439,8 @@ class  ThinkTemplate {
             $tagStr = stripslashes($tagStr);
         //}
         //还原非模板标签
-        if($tagStr=""||preg_match('/^[\s|\d]/is',$tagStr))
-            //过滤空格和数字打头的标签
+        if($tagStr==''||preg_match('/^[\s|\d]/is',$tagStr))
+            //过滤空白、空格和数字打头的标签
             return C('TMPL_L_DELIM') . $tagStr .C('TMPL_R_DELIM');
         $flag   =  substr($tagStr,0,1);
         $name   = substr($tagStr,1);


### PR DESCRIPTION
原来的正则替换可能导致在模板中{}{$name}这样的语法不能正确解析，尤其是当使用js的try{...}catch(e){}这样的句子时，肯定存在问题。
这个问题我也是刚刚发现的，希望能考虑一下。
谢谢。
