### PR TITLE
ajax方式下，无日志的Bug

### DIFF
--- a/ThinkPHP/Lib/Core/Log.class.php
+++ b/ThinkPHP/Lib/Core/Log.class.php
@@ -78,6 +78,7 @@ class Log {
             $destination   =   $destination?$destination:C('LOG_DEST');
             $extra   =  $extra?$extra:C('LOG_EXTRA');
         }
+	    $destination = dirname($_SERVER['SCRIPT_FILENAME']).'/'.$destination;
         $now = date(self::$format);
         error_log($now.' '.get_client_ip().' '.$_SERVER['REQUEST_URI']."\r\n".implode('',self::$log)."\r\n", $type,$destination ,$extra);
         // 保存后清空日志缓存


### PR DESCRIPTION
apache析构函数会改变当前程序的目录，使用相对目录，找不到对应的文件而写入失败
