### PR TITLE
修复查询缓存无法设置过期时间

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -380,19 +380,21 @@ function S($name,$value='',$options=null) {
         // 缓存操作的同时初始化
         $type       =   isset($options['type'])?$options['type']:'';
         $cache      =   Cache::getInstance($type,$options);
+        $expire     =   is_numeric($options['expire'])?$options['expire']:NULL;	//修复查询缓存无法设置过期时间
     }elseif(is_array($name)) { // 缓存初始化
         $type       =   isset($name['type'])?$name['type']:'';
         $cache      =   Cache::getInstance($type,$name);
         return $cache;
     }elseif(empty($cache)) { // 自动初始化
         $cache      =   Cache::getInstance();
+        $expire     =   is_numeric($options)?$options:NULL;	//默认快捷缓存设置过期时间
     }
     if(''=== $value){ // 获取缓存
         return $cache->get($name);
     }elseif(is_null($value)) { // 删除缓存
         return $cache->rm($name);
     }else { // 缓存数据
-        $expire     =   is_numeric($options)?$options:NULL;
+        //$expire     =   is_numeric($options)?$options:NULL;	//原始语句
         return $cache->set($name, $value, $expire);
     }
 }


### PR DESCRIPTION
修复“查询缓存”无法设置过期时间问题，手册中：$Model->cache('cache_name',60)->select();
此方式expire会以options[expire]数组传入S方法，S方法未对options[expire] 参数进行处理，仅处理当 options 为数字时过期时间情况。所以仅支持 S(key,value,expire) 方式设置过期时间。
