### PR TITLE
ob头优先输出

### DIFF
--- a/ThinkPHP/Lib/Core/App.class.php
+++ b/ThinkPHP/Lib/Core/App.class.php
@@ -25,6 +25,11 @@ class App {
      * @return void
      */
     static public function init() {
+        // 页面压缩输出支持
+        if(C('OUTPUT_ENCODE')){
+            $zlib = ini_get('zlib.output_compression');
+            if(empty($zlib)) ob_start('ob_gzhandler');
+        }
         // 设置系统时区
         date_default_timezone_set(C('DEFAULT_TIMEZONE'));
         // 加载动态项目公共文件和配置
@@ -43,11 +48,6 @@ class App {
 
         // URL调度结束标签
         tag('url_dispatch');         
-        // 页面压缩输出支持
-        if(C('OUTPUT_ENCODE')){
-            $zlib = ini_get('zlib.output_compression');
-            if(empty($zlib)) ob_start('ob_gzhandler');
-        }
         // 系统变量安全过滤
         if(C('VAR_FILTERS')) {
             $filters    =   explode(',',C('VAR_FILTERS'));


### PR DESCRIPTION
建议ob头在最前输出，因为load_ext_file()所加载的方法中可能会导致ob输出异常
