### PR TITLE
修正普通分组模式下模块跨分组调用, 模板include跨分组路径错误bug

### DIFF
--- a/ThinkPHP/Lib/Behavior/LocationTemplateBehavior.class.php
+++ b/ThinkPHP/Lib/Behavior/LocationTemplateBehavior.class.php
@@ -40,11 +40,10 @@ class LocationTemplateBehavior extends Behavior {
             if(strpos($templateFile,'@')){
                 list($group,$templateFile) =    explode('@',$templateFile);
                 if(1==C('APP_GROUP_MODE')){
-                    $basePath   =   dirname(BASE_LIB_PATH).'/';
+                      $basePath   =   dirname(BASE_LIB_PATH).'/'.$group.'/'.basename(TMPL_PATH).'/'.(THEME_NAME?THEME_NAME.'/':'');
                 }else{
-                    $basePath   =   TMPL_PATH;
+                      $basePath   =   TMPL_PATH.'/'.$group.'/'.(THEME_NAME?THEME_NAME.'/':'');
                 }
-                $basePath  .=   $group.'/'.basename(TMPL_PATH).'/'.(THEME_NAME?THEME_NAME.'/':'');
             }else{
                 $basePath   =   THEME_PATH;
             }

--- a/ThinkPHP/Lib/Template/ThinkTemplate.class.php
+++ b/ThinkPHP/Lib/Template/ThinkTemplate.class.php
@@ -675,11 +675,10 @@ class  ThinkTemplate {
                 if(strpos($templateName,'@')){
                     list($group,$templateName) =    explode('@',$templateName);
                     if(1==C('APP_GROUP_MODE')){
-                        $basePath   =   dirname(BASE_LIB_PATH).'/';
-                    }else{
-                        $basePath   =   TMPL_PATH;
-                    }
-                    $basePath  .=   $group.'/'.basename(TMPL_PATH).'/'.(THEME_NAME?THEME_NAME.'/':'');
+	                      $basePath   =   dirname(BASE_LIB_PATH).'/'.$group.'/'.basename(TMPL_PATH).'/'.(THEME_NAME?THEME_NAME.'/':'');
+	                }else{
+	                      $basePath   =   TMPL_PATH.'/'.$group.'/'.(THEME_NAME?THEME_NAME.'/':'');
+	                }
                 }else{
                     $basePath   =   THEME_PATH;
                 }


### PR DESCRIPTION
模块模板跨分组调用在独立分组模式下工作正常, 在普通分组模式下拼接出错了.
