### PR TITLE
修正D方法创建Model后，无法在Model通过$this->tableName获取当前不带前缀表名的BUG

### DIFF
--- a/ThinkPHP/Lib/Core/Model.class.php
+++ b/ThinkPHP/Lib/Core/Model.class.php
@@ -1217,13 +1217,10 @@ class Model {
      */
     public function getTableName() {
         if(empty($this->trueTableName)) {
-            $tableName  = !empty($this->tablePrefix) ? $this->tablePrefix : '';
-            if(!empty($this->tableName)) {
-                $tableName .= $this->tableName;
-            }else{
-                $tableName .= parse_name($this->name);
+            if (empty($this->tableName)) {
+                $this->tableName = strtolower(parse_name($this->name));
             }
-            $this->trueTableName    =   strtolower($tableName);
+            $this->trueTableName = strtolower((empty($this->tablePrefix) ? '' : $this->tablePrefix) . $this->tableName);
         }
         return (!empty($this->dbName)?$this->dbName.'.':'').$this->trueTableName;
     }


### PR DESCRIPTION
修正D方法创建Model后，无法在Model通过$this->tableName获取当前不带前缀表名的BUG
