### PR TITLE
修正动态扩展模型方法里面的属性传递

### DIFF
--- a/ThinkPHP/Lib/Core/Model.class.php
+++ b/ThinkPHP/Lib/Core/Model.class.php
@@ -173,8 +173,8 @@ class Model {
         $this->_extModel   = new $class($this->name);
         if(!empty($vars)) {
             // 传入当前模型的属性到扩展模型
-            foreach ($vars as $var)
-                $this->_extModel->setProperty($var,$this->$var);
+            foreach ($vars as $key=>$var)
+                $this->_extModel->setProperty($key, $var);
         }
         return $this->_extModel;
     }


### PR DESCRIPTION
按照现在手册里面的操作，第二个参数是传不进去的。

``` php
$UserView = $User->switchModel("View",array("viewFields"));
```

这样修改后，可以这样来传

``` php
$viewFields = array(
     'Blog'=>array('id','name','title'),
     'Category'=>array('title'=>'category_name', '_on'=>'Blog.category_id=Category.id'),
     'User'=>array('name'=>'username', '_on'=>'Blog.user_id=User.id'),
   );
$UserView = $User->switchModel("View",array("viewFields"=>$viewFields));
```
