### PR TITLE
保持$this->options里面table的记录

### DIFF
--- a/ThinkPHP/Lib/Core/Model.class.php
+++ b/ThinkPHP/Lib/Core/Model.class.php
@@ -530,6 +530,7 @@ class Model {
             $options =  array_merge($this->options,$options);
         // 查询过后清空sql表达式组装 避免影响下次查询
         $this->options  =   array();
+        $this->options['table'] = $options['table'];
         if(!isset($options['table'])){
             // 自动获取表名
             $options['table']   =   $this->getTableName();


### PR DESCRIPTION
我在UserModel写了一个getDao方法，用于分表后指定要操作的数据表。

``` php
public function getDao($username) 
    {
        $partition = array(
            'field' =>  'username',
            'type'  =>  'md5',
            'num'   =>  2,
        );
        $userAdv = $this->switchModel('Adv');
        $userAdv->setProperty('partition', $partition);
        $table = $userAdv->getPartitionTableName(array('username'=>$username));

        return $this->table($table);
    }
```

然后UserModel有一个自动验证配置

``` php
array('username', '', '该用户名已经被使用', Model::EXISTS_VALIDATE, 'unique', Model::MODEL_INSERT)
```

我通过下面的代码创建数据对象，自动验证、自动完成

``` php
$userDao = D('User')->getDao($_POST['username']);
$userDao->create();
```

因为在前面清空了$this->options['table']导致在create()方法的字段检测里面获取不到当前分表的字段，原来应该是user_1表结果还是获取user表。导致最后的数据对象出错。

这样重新保存一下$this->options['table']就没问题了。
