### PR TITLE
URL_CASE_INSENSITIVE参数作用，统一Group、Module和Action的效果。

### DIFF
--- a/ThinkPHP/Lib/Core/Dispatcher.class.php
+++ b/ThinkPHP/Lib/Core/Dispatcher.class.php
@@ -253,8 +253,12 @@ class Dispatcher {
                     return   '';
                 }
             }
-        }        
-        return strip_tags(C('URL_CASE_INSENSITIVE')?strtolower($action):$action);
+        }
+        if(C('URL_CASE_INSENSITIVE')) {
+            // URL地址不区分大小写
+            $action = ucfirst(parse_name($action,1));
+        }
+        return strip_tags($action);
     }
 
     /**
@@ -265,7 +269,11 @@ class Dispatcher {
     static private function getGroup($var) {
         $group   = (!empty($_GET[$var])?$_GET[$var]:C('DEFAULT_GROUP'));
         unset($_GET[$var]);
-        return strip_tags(C('URL_CASE_INSENSITIVE') ?ucfirst(strtolower($group)):$group);
+        if(C('URL_CASE_INSENSITIVE')) {
+            // URL地址不区分大小写
+            $group = ucfirst(parse_name($group,1));
+        }
+        return strip_tags($group);
     }
 
 }


### PR DESCRIPTION
为了保证风格的统一，以及SEO的优化，在URL_CASE_INSENSITIVE参数作用下，
增加了对action和group的智能识别。
现在，当访问：
http://www.thinkphp.cn/group_name/module_name/action_name
将会访问：
{APP_PATH}/Lib/Action/GroupName/ModuleNameAction.class.php文件中
ModuleNameAction::ActionName()方法。
