### PR TITLE
修复当配置文件二维数组（第二层）键名为小写时，无法通过C方法（参数大写的情况）读取配置的Bug

### DIFF
--- a/ThinkPHP/Common/common.php
+++ b/ThinkPHP/Common/common.php
@@ -544,8 +544,8 @@ function C($name=null, $value=null) {
             return;
         }
         // 二维数组设置和获取支持
+		$name = strtolower($name);
         $name = explode('.', $name);
-        $name[0]   =  strtolower($name[0]);
         if (is_null($value))
             return isset($_config[$name[0]][$name[1]]) ? $_config[$name[0]][$name[1]] : null;
         $_config[$name[0]][$name[1]] = $value;


### PR DESCRIPTION
例如：在项目配置文件config.php中，有「'ADMIN_INFO' =>array('nickname' => 'phplaber', 'sex' => 'male')」这一项，目前通过：C('ADMIN_INFO.NICKNAME')获取不到配置值，但通过C('ADMIN_INFO.nickname')可以获取到。
