### PR TITLE
开启LAYOUT_ON时，在系统内置页面跳转模板里添加{__NOLAYOUT__}

### DIFF
--- a/ThinkPHP/Tpl/dispatch_jump.tpl
+++ b/ThinkPHP/Tpl/dispatch_jump.tpl
@@ -1,3 +1,8 @@
+<?php
+    if(C('LAYOUT_ON')) {
+        echo '{__NOLAYOUT__}';
+    }
+?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>

--- a/ThinkPHP/Tpl/think_exception.tpl
+++ b/ThinkPHP/Tpl/think_exception.tpl
@@ -1,3 +1,8 @@
+<?php
+    if(C('LAYOUT_ON')) {
+        echo '{__NOLAYOUT__}';
+    }
+?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"><head>
 <meta content="text/html; charset=utf-8" http-equiv="Content-Type">


### PR DESCRIPTION
修复使用布局模板时Action内置error和success函数不可用问题

另外，关于主题（DEFAULT_THEME）和分组（DEFAULT_GROUP）的配置需要在主题或模板名字后面加一个路径分隔符。详情如下：

ThinkPHP/Lib/Core/View.class.php: 150-156

```
// 获取当前主题的模版路径
if(1==C('APP_GROUP_MODE')){ // 独立分组模式
    define('THEME_PATH',   dirname(BASE_LIB_PATH).'/'.$group.basename(TMPL_PATH).'/'.$theme);
    define('APP_TMPL_PATH',__ROOT__.'/'.$app_name.C('APP_GROUP_PATH').'/'.$group.basename(TMPL_PATH).'/'.$theme);
}else{ 
    define('THEME_PATH',   TMPL_PATH.$group.$theme);
    define('APP_TMPL_PATH',__ROOT__.'/'.$app_name.basename(TMPL_PATH).'/'.$group.$theme);
}
```

**获取的模板路径最后没有路径分隔符**

ThinkPHP/Lib/Template/ThinkTemplate.class.php: 110

```
$layoutFile  =  THEME_PATH.C('LAYOUT_NAME').$this->config['template_suffix'];
```

**此处调用时在 THEME_PATH 和 LAYOUT_NAME 之间也没有加分隔符**
