### PR TITLE
引入扩展行为配置错误

### DIFF
--- a/ThinkPHP/Conf/Mode/common.php
+++ b/ThinkPHP/Conf/Mode/common.php
@@ -80,7 +80,5 @@ return array(
 	    ),
 	    'view_end'      =>  array(),
 	),
-	'tags'	=>	array(
-		COMMON_PATH.'Conf/tags.php',
-	),
+	'tags'	=> COMMON_PATH.'Conf/tags.php',
 );


### PR DESCRIPTION
Hook::import(is_array($mode['tags'])?$mode['tags']:include $mode['tags']);
这是Tink.class.php里的78行的
要非数组才会引入文件
