### PR TITLE
T函数解析模板路径的时候 带上主题参数后 生成的路径错误

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -147,9 +147,7 @@ function T($template='',$layer=''){
     }
     // 获取主题
     $array  =   explode('/',$file);
-    if(count($array)>2){
-        $theme  =   array_shift($array);
-    }else{
+    if(count($array)<3){
         $theme  =   C('DEFAULT_THEME');
     }
     // 分析模板文件规则


### PR DESCRIPTION
如果T的参数为module@theme/controller/method
解析出来的路径为
./App/module/View/theme/theme/controller/method.html

多了一个theme
