### PR TITLE
修复 ->order() 排序字符串中包含空格的情况下 order 条件生成错误 的 bug

### DIFF
--- a/ThinkPHP/Library/Think/Model/ViewModel.class.php
+++ b/ThinkPHP/Library/Think/Model/ViewModel.class.php
@@ -125,6 +125,7 @@ class ViewModel extends Model {
      */
     protected function checkOrder($order='') {
          if(is_string($order) && !empty($order)) {
+            $order = trim($order);
             $orders = explode(',',$order);
             $_order = array();
             foreach ($orders as $order){


### PR DESCRIPTION
如 order('a DESC, b DESC') 会生成 'tab.a DESC,b'，期望得到的是 'tab.a DESC,tab.b DESC'
