### PR TITLE
修正RestController类的执行顺序

### DIFF
--- a/ThinkPHP/Library/Think/Controller/RestController.class.php
+++ b/ThinkPHP/Library/Think/Controller/RestController.class.php
@@ -38,7 +38,6 @@ class RestController extends Controller {
      * @access public
      */
     public function __construct() {
-        parent::__construct();
         // 资源类型检测
         if(''==__EXT__) { // 自动检测资源类型
             $this->_type   =  $this->getAcceptType();
@@ -57,6 +56,8 @@ class RestController extends Controller {
             $method = $this->defaultMethod;
         }
         $this->_method = $method;
+        
+        parent::__construct();
     }
 
     /**


### PR DESCRIPTION
修正后，子类在_initialize()中可以继承父类__construct()的内容：

class ServerController extends RestController {
  public function _initialize() {
    var_dump($this->_type);
  }
}
