### PR TITLE
Update Model.class.php

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -795,7 +795,7 @@ class Model {
                     if(2==$count) {
                         $cols[$name]   =  $result[$key2];
                     }else{
-                        $cols[$name]   =  is_string($sepa)?implode($sepa,$result):$result;
+                        $cols[$name]   =  is_string($sepa)?implode($sepa,array_slice($result,1)):$result;
                     }
                 }
                 if(isset($cache)){


### PR DESCRIPTION
修复返回结果与开发手册描述不符的BUG
例如：
$list = $User->getField('id,nickname,email',':');
期望返回 `id`=>'nickname:email'
实际返回 `id`=>'id:nickname:email'
