### PR TITLE
修复改变模块视图到全局的视图目录功能

### DIFF
--- a/ThinkPHP/Library/Think/View.class.php
+++ b/ThinkPHP/Library/Think/View.class.php
@@ -153,13 +153,18 @@ class View {
         // 获取当前主题的模版路径
         if(!defined('THEME_PATH')){
             if(C('VIEW_PATH')){ // 模块设置独立的视图目录
-                $tmplPath   =   C('VIEW_PATH');
+                $tmplPath   =   C('VIEW_PATH').$theme;
             }else{  // 定义TMPL_PATH 改变全局的视图目录到模块之外
-                $tmplPath   =   defined('TMPL_PATH')? TMPL_PATH.$module.'/' : APP_PATH.$module.'/'.C('DEFAULT_V_LAYER').'/';
+                if (C('DENY_TMPL_PATH')) {
+                    $tmplPath = APP_PATH.$module.'/'.C('DEFAULT_V_LAYER').'/'.$theme;
+                } elseif (defined('TMPL_PATH')) {
+                    $tmplPath   =   TMPL_PATH.$theme.$module.'/';
+                } else {
+                    $tmplPath = APP_PATH.$module.'/'.C('DEFAULT_V_LAYER').'/'.$theme;
+                }
             }
-            define('THEME_PATH', $tmplPath.$theme);
+            define('THEME_PATH', $tmplPath);
         }
-
         // 分析模板文件规则
         if('' == $template) {
             // 如果模板文件名为空 按照默认规则定位


### PR DESCRIPTION
假想使用场景：一个个应用中有Admin Blog User这三个模块，Blog User 模块的视图文件我希望放到一个公共的目录下，有点类似于wordpress中的wp-content/themes目录下存放的内容，同时Admin模块的视图文件我不希望放到公共的目录下

解决思路：
修改了下面这些代码
在index.php中定义TMPL_PATH: define('TMPL_PATH', './Themes');
因为不希望Admin视图放到 ./Themes 下，所以 在Admin模块下的 Conf/config.yaml 下定义DENY_TMPL_PATH: true

我不清楚原来的TMPL_PATH的作用是不是所说的上面这个作用，我怕我理解错了
另外增加了DENY_TMPL_PATH配置，用来禁止将模块视图目录放到公共目录下
