### PR TITLE
dump函数中关于xdebug的判断

### DIFF
--- a/ThinkPHP/Common/functions.php
+++ b/ThinkPHP/Common/functions.php
@@ -635,7 +635,7 @@ function dump($var, $echo=true, $label=null, $strict=true) {
         ob_start();
         var_dump($var);
         $output = ob_get_clean();
-        if (!extension_loaded('xdebug')) {
+        if (!ini_get('xdebug.overload_var_dump')) {
             $output = preg_replace('/\]\=\>\n(\s+)/m', '] => ', $output);
             $output = '<pre>' . $label . htmlspecialchars($output, ENT_QUOTES) . '</pre>';
         }


### PR DESCRIPTION
这里不应该用extension_loaded('xdebug')来判断，正确的做法是判断ini_get('xdebug.overload_var_dump')
