### PR TITLE
自动创建模型模块的父目录

### DIFF
--- a/ThinkPHP/Library/Think/Build.class.php
+++ b/ThinkPHP/Library/Think/Build.class.php
@@ -122,6 +122,10 @@ class [MODEL]Model extends Model {
             if(!C('APP_USE_NAMESPACE')){
                 $content    =   preg_replace('/namespace\s(.*?);/','',$content,1);
             }
+            $dir = dirname($file);
+            if(!is_dir($dir)){
+                mkdir($dir, 0755, true);
+            }
             file_put_contents($file,$content);
         }
     }
@@ -133,6 +137,10 @@ class [MODEL]Model extends Model {
             $content = str_replace(array('[MODULE]','[MODEL]'),array($module,$model),self::$model);
             if(!C('APP_USE_NAMESPACE')){
                 $content    =   preg_replace('/namespace\s(.*?);/','',$content,1);
+            }
+            $dir = dirname($file);
+            if(!is_dir($dir)){
+                mkdir($dir, 0755, true);
             }
             file_put_contents($file,$content);
         }


### PR DESCRIPTION
#  直接调用 \Think\Build::buildController 和 buildModel 的情况下创建目录。

单独使用一个脚本生成代码的情况下，可能因为父目录不存在而无法创建类文件；
用 BIND_MODULE 的时候 BUILD_CONTOLLER_LIST  是先通过 Build::buildAppDir() 这个方法里生成目录了，不会出现写文件失败的情况。
