### PR TITLE
增加Model类对复合主键的支持

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -315,8 +315,9 @@ class Model {
         // 写入数据到数据库
         $result = $this->db->insert($data,$options,$replace);
         if(false !== $result ) {
+            $pk     =   $this->getPk();
               // 增加复合主键支持
-            if (is_array($this->getPk())) return $result;
+            if (is_array($pk)) return $result;
             $insertId   =   $this->getLastInsID();
             if($insertId) {
                 // 自增主键返回插入ID


### PR DESCRIPTION
使用getPk()时，如果是复合主键会返回一个包含字段的数组。
在delete()、select()、find()时如果传入一个数组则会按对应的复合主键生成where条件
add()、save()、_validationFieldItem也作了相应改动
