### PR TITLE
修复mongodb驱动的配置变量错误

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
@@ -47,7 +47,7 @@ class Mongo extends Driver {
      */
     public function connect($config='',$linkNum=0) {
         if ( !isset($this->linkID[$linkNum]) ) {
-            if(empty($config))  $config =   $this->config['connection'];
+            if(empty($config))  $config =   $this->config;
             $host = 'mongodb://'.($config['username']?"{$config['username']}":'').($config['password']?":{$config['password']}@":'').$config['hostname'].($config['hostport']?":{$config['hostport']}":'').'/'.($config['database']?"{$config['database']}":'');
             try{
                 $this->linkID[$linkNum] = new \mongoClient( $host,$this->config['params']);


### PR DESCRIPTION
链接方法的配置变量错了，连接不到MONGODB，现在修正。
