### PR TITLE
Update Log.class.php

### DIFF
--- a/ThinkPHP/Lib/Core/Log.class.php
+++ b/ThinkPHP/Lib/Core/Log.class.php
@@ -101,7 +101,7 @@ class Log {
         $type = $type?$type:C('LOG_TYPE');
         if(self::FILE == $type) { // 文件方式记录日志
             if(empty($destination))
-                $destination = LOG_PATH.date('y_m_d').'.log';
+                $destination = C('LOG_PATH').date('y_m_d').'.log';
             //检测日志文件大小，超过配置大小则备份日志文件重新生成
             if(is_file($destination) && floor(C('LOG_FILE_SIZE')) <= filesize($destination) )
                   rename($destination,dirname($destination).'/'.time().'-'.basename($destination));


### PR DESCRIPTION
改进日志写入的时候 获取LOG_PATH绝对路径
修复：error_log(./App/Runtime/Logs/14_08_19.log): failed to open stream: No such file or directory Log.class.php 第 96 行.
