### PR TITLE
修复sqlsrv驱动SQL指令安全过滤BUG

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver/Sqlsrv.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver/Sqlsrv.class.php
@@ -161,4 +161,13 @@ class Sqlsrv extends Driver{
         return $this->execute($sql,$this->parseBind(!empty($options['bind'])?$options['bind']:array()));
     }
 
+    /**
+     * SQL指令安全过滤
+     * @access public
+     * @param string $str  SQL字符串
+     * @return string
+     */
+    public function escapeString($str) {
+        return preg_replace("/[']/", "\\0\\0", $str);
+    }
 }


### PR DESCRIPTION
mssql的转义字符并非反斜杠，而是以两个连续的单引号表示一个单引号实体，通过在sqlsrv驱动类重写escapeString方法修复此问题
