### PR TITLE
Update Firebird.class.php

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver/Firebird.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver/Firebird.class.php
@@ -16,7 +16,8 @@ use Think\Db\Driver;
  */
 class Firebird extends Driver{
     protected $selectSql  =     'SELECT %LIMIT% %DISTINCT% %FIELD% FROM %TABLE%%JOIN%%WHERE%%GROUP%%HAVING%%ORDER%';
-
+    protected $options = array();
+    
     /**
      * 解析pdo连接的dsn信息
      * @access public


### PR DESCRIPTION
通常Firebird的字段名都是大写的，Driver定义了强制小写反而会使字段排除功能失效
