### PR TITLE
支持对非local驱动的文件检测支持

### DIFF
--- a/ThinkPHP/Library/Think/Upload.class.php
+++ b/ThinkPHP/Library/Think/Upload.class.php
@@ -169,7 +169,7 @@ class Upload {
             /* 调用回调函数检测文件是否存在 */
             $data = call_user_func($this->callback, $file);
             if( $this->callback && $data ){
-                if ( file_exists('.'.$data['path'])  ) {
+                if ($this->isFileExists($data)) {
                     $info[$key] = $data;
                     continue;
                 }elseif($this->removeTrash){
@@ -216,7 +216,17 @@ class Upload {
         }
         return empty($info) ? false : $info;
     }
-
+    /**
+     * 检测文件是否存在
+     * @access private
+     * @param array $files  上传的文件变量
+     * @return bool
+     */
+    private function isFileExists($data){
+        $file = $data['url'];
+        $file_headers = @get_headers($file);
+        return $file_headers[0] != 'HTTP/1.1 404 Not Found';
+    }
     /**
      * 转换上传文件数组变量为正确的方式
      * @access private


### PR DESCRIPTION
file_exists无法检测远程文件，如qiniu、alioss等。
这里修改为通过file_header的方式判断。