### PR TITLE
调用_before_update没有传primary key，导致高级模型检查乐观锁出错

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -428,7 +428,6 @@ class Model {
                         $this->error        =   L('_OPERATION_WRONG_');
                         return false;
                     }
-                    unset($data[$pk]);
                 }
             }
             if(!isset($where)){
@@ -446,6 +445,7 @@ class Model {
         if(false === $this->_before_update($data,$options)) {
             return false;
         }
+        unset($data[$pk]);
         $result     =   $this->db->update($data,$options);
         if(false !== $result && is_numeric($result)) {
             if(isset($pkValue)) $data[$pk]   =  $pkValue;


### PR DESCRIPTION
见https://github.com/liu21st/extend/blob/master/Extend/Model/AdvModel.class.php  170行
如果不给_before_update传primary key数据，就会造成notice报错、乐观锁数据混乱的问题。而且理论上来说，_before_update有权获得完整数据。
