### PR TITLE
Update ArrayList.class.php

### DIFF
--- a/ThinkPHP/Library/Org/Util/ArrayList.class.php
+++ b/ThinkPHP/Library/Org/Util/ArrayList.class.php
@@ -16,7 +16,7 @@ namespace Org\Util;
  * @subpackage  Util
  * @author    liu21st <liu21st@gmail.com>
  */
-class ArrayList implements IteratorAggregate {
+class ArrayList implements \IteratorAggregate {
 
     /**
      * 集合元素


### PR DESCRIPTION
在使用namespace的情况下, 不对IteratorAggregate添加反斜杠不会报错?
还是此类已在Org\Util下面有了?
