### PR TITLE
修复condition表达式的转化问题

### DIFF
--- a/ThinkPHP/Library/Think/Template/TagLib.class.php
+++ b/ThinkPHP/Library/Think/Template/TagLib.class.php
@@ -128,16 +128,16 @@ class TagLib {
         $condition = preg_replace('/\$(\w+):(\w+)\s/is','$\\1->\\2 ',$condition);
         switch(strtolower(C('TMPL_VAR_IDENTIFY'))) {
             case 'array': // 识别为数组
-                $condition  =   preg_replace('/\$(\w+)\.(\w+)\s/is','$\\1["\\2"] ',$condition);
+                $condition  =   preg_replace('/\$(\w+)\.(\w+)(\s|$)/is','$\\1["\\2"] ',$condition);
                 break;
             case 'obj':  // 识别为对象
-                $condition  =   preg_replace('/\$(\w+)\.(\w+)\s/is','$\\1->\\2 ',$condition);
+                $condition  =   preg_replace('/\$(\w+)\.(\w+)(\s|$)/is','$\\1->\\2 ',$condition);
                 break;
             default:  // 自动判断数组或对象 只支持二维
-                $condition  =   preg_replace('/\$(\w+)\.(\w+)\s/is','(is_array($\\1)?$\\1["\\2"]:$\\1->\\2) ',$condition);
+                $condition  =   preg_replace('/\$(\w+)\.(\w+)(\s|$)/is','(is_array($\\1)?$\\1["\\2"]:$\\1->\\2) ',$condition);
         }
         if(false !== strpos($condition, '$Think'))
-            $condition      =   preg_replace_callback('/(\$Think.*?)\s/is', array($this, 'parseThinkVar'), $condition);        
+            $condition      =   preg_replace_callback('/(\$Think.*?)(\s|$)/is', array($this, 'parseThinkVar'), $condition);        
         return $condition;
     }
 


### PR DESCRIPTION
在模版中，类似
<if condition="$plist.name eq $apply.plan_province">
这样的表达式，在转换成模版之后，condition会变成“$plist["name"] == $apply.plan_province”，右边的变量没有被转换，经过研究是这个正则表达式的问题。
当然。。。改成这样<if condition="$plist.name eq $apply.plan_province ">(多加一个空格)，也可以解决问题。。就看便利不便利了。。不去读框架代码。。大概不知道这样子吧。。。。
