### PR TITLE
compiler函数在编译模板时，需要人为添加换行

### DIFF
--- a/ThinkPHP/Library/Think/Template.class.php
+++ b/ThinkPHP/Library/Think/Template.class.php
@@ -131,7 +131,7 @@ class  Template {
         // 优化生成的php代码
         $tmplContent = str_replace('?><?php','',$tmplContent);
         // 人为添加一个换行
-        $tmplContent = str_replace("\r\n","\n",$tmplContent);
+        $tmplContent = str_replace("?>\r\n","?>\r\n\r\n",$tmplContent);
         $tmplContent = str_replace("?>\n","?>\n\n",$tmplContent);
         // 模版编译过滤标签
         Hook::listen('template_filter',$tmplContent);


### PR DESCRIPTION
PHP的?>后面的紧跟的换行会被PHP解析器给吃掉，例如以下代码：
<?php echo "hello" ?>
world
PHP解析器解析执行后，输出
helloworld
而不是
hello
world

PHP文档说明如下：
    “The closing tag for the block will include the immediately trailing newline if one is present.”
    节选自：http://php.net/manual/en/language.basic-syntax.instruction-separation.php

假如我们的模板如下：
My name is {$name}
Bye
解析后，我们可能得到的输出就是：
My name is ObamaBye
如果上面模板是发给客户的email的内容，丢失的换行会影响email的格式。

因此，我们要人为的增加一个换行，已保证模板解析后不会丢失换行。
