### PR TITLE
内存溢出问题

### DIFF
--- a/ThinkPHP/Common/common.php
+++ b/ThinkPHP/Common/common.php
@@ -737,7 +737,13 @@ function array_define($array,$check=true) {
  * @return void
  */
 function trace($value='[think]',$label='',$level='DEBUG',$record=false) {
-    static $_trace =  array();
+    static $_trace =  array(); // 没有限制长度的话这个会溢出的
+
+    // 限制记录长度为1000条
+    if(count($_trace, COUNT_RECURSIVE) > 1000){
+        $_trace = array();
+    }
+
     if('[think]' === $value){ // 获取trace信息
         return $_trace;
     }else{


### PR DESCRIPTION
如果在cli里执行事务的话 重复读取数据库 M/D函数, 会导致这个trace把内存写满
