### PR TITLE
Route.class.php 判断是否是整数的判断BUG

### DIFF
--- a/ThinkPHP/Library/Think/Route.class.php
+++ b/ThinkPHP/Library/Think/Route.class.php
@@ -149,7 +149,7 @@ class Route
                             if (!empty($val[2])) {
                                 if ($val[2] == 'int') {
                                     // 是否为数字
-                                    if (!is_numeric($vars[$key]) || !is_int($vars[$key] + 0)) {
+                                    if (!is_numeric($vars[$key]) || !is_int($vars[$key])) {
                                         break;
                                     }
                                 } else {
@@ -409,7 +409,7 @@ class Route
                         // 设置了过滤条件
                         if ($val[2] == 'int') {
                             // 如果值不为整数
-                            if (!is_int($var + 0)) {
+                            if (!is_int($var)) {
                                 return false;
                             }
                         } else {


### PR DESCRIPTION
生成参数时由于没有正确的判断，导致生成的参数错误
"string"+0后在php5.5.12（实测版本）会转换成int(0)导致判断错误