### PR TITLE
Update RestController.class.php

### DIFF
--- a/ThinkPHP/Library/Think/Controller/RestController.class.php
+++ b/ThinkPHP/Library/Think/Controller/RestController.class.php
@@ -104,6 +104,7 @@ class RestController extends Controller
     protected function getAcceptType()
     {
         $type = array(
+            'html' => 'text/html,application/xhtml+xml,*/*',
             'xml'  => 'application/xml,text/xml,application/x-xml',
             'json' => 'application/json,text/x-json,application/jsonrequest,text/json',
             'js'   => 'text/javascript,application/javascript,application/x-javascript',
@@ -117,7 +118,6 @@ class RestController extends Controller
             'jpg'  => 'image/jpg,image/jpeg,image/pjpeg',
             'gif'  => 'image/gif',
             'csv'  => 'text/csv',
-            'html' => 'text/html,application/xhtml+xml,*/*',
         );
 
         foreach ($type as $key => $val) {


### PR DESCRIPTION
当url未定义访问类型时，如：http://localhost/Home/Index/index
其HTTP_ACCEPT为：text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
应该优先匹配 'html' => 'text/html,application/xhtml+xml,*/*',
而不是xml