### PR TITLE
Memcached 驱动过期时间设置问题

### DIFF
--- a/ThinkPHP/Library/Think/Cache/Driver/Memcached.class.php
+++ b/ThinkPHP/Library/Think/Cache/Driver/Memcached.class.php
@@ -72,7 +72,8 @@ class Memcached extends Cache
             $expire = $this->options['expire'];
         }
         $name = $this->options['prefix'] . $name;
-        if ($this->handler->set($name, $value, time() + $expire)) {
+        $expire = $expire == 0 ? 0 : time() + $expire;
+        if ($this->handler->set($name, $value, $expire)) {
             if ($this->options['length'] > 0) {
                 // 记录缓存队列
                 $this->queue($name);


### PR DESCRIPTION
#382 

http://php.net/manual/zh/memcached.expiration.php

在 $expire 为 0 （永不过期）时
Memached 的过期时间需要设置为 
0 （永不过期） 
而不是 
time() + $expire （立即失效）