### PR TITLE
修改了IpLocation类的构造函数

### DIFF
--- a/ThinkPHP/Library/Org/Net/IpLocation.class.php
+++ b/ThinkPHP/Library/Org/Net/IpLocation.class.php
@@ -54,7 +54,10 @@ class IpLocation
     public function __construct($filename = "UTFWry.dat")
     {
         $this->fp = 0;
-        if (($this->fp = fopen(dirname(__FILE__) . '/' . $filename, 'rb')) !== false) {
+        if(!is_file($filename)) {
+            $filename = dirname(__FILE__) . '/' . $filename;
+        }
+        if (($this->fp = fopen($filename, 'rb')) !== false) {
             $this->firstip = $this->getlong();
             $this->lastip  = $this->getlong();
             $this->totalip = ($this->lastip - $this->firstip) / 7;


### PR DESCRIPTION
修改了IpLocation类的构造函数，允许传入的参数是一个文件的绝对路径，如果不是绝对路径，再考虑使用原来的方法在类库的当前文件夹下寻找文件。