### PR TITLE
多数据库，初始化Model时对数据表前缀内容的修复

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -93,7 +93,7 @@ class Model
         } elseif ('' != $tablePrefix) {
             $this->tablePrefix = $tablePrefix;
         } elseif (!isset($this->tablePrefix)) {
-            $this->tablePrefix = C('DB_PREFIX');
+            $this->tablePrefix = empty($this->connection) ? C('DB_PREFIX') : C($this->connection.'.DB_PREFIX');
         }
 
         // 数据库初始化操作

--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -93,7 +93,7 @@ class Model
         } elseif ('' != $tablePrefix) {
             $this->tablePrefix = $tablePrefix;
         } elseif (!isset($this->tablePrefix)) {
-            $this->tablePrefix = empty($this->connection) ? C('DB_PREFIX') : C($this->connection.'.DB_PREFIX');
+            $this->tablePrefix = !empty($this->connection) && !is_null(C($this->connection.'.DB_PREFIX')) ? C($this->connection.'.DB_PREFIX') : C('DB_PREFIX');
         }
 
         // 数据库初始化操作


### PR DESCRIPTION
多个数据库配置时，如果不同的数据库使用了不同的表前缀，这里需要根据不同数据库的配置决定数据表的前缀