### PR TITLE
修复 Hook ajax_return 逻辑错误

### DIFF
--- a/ThinkPHP/Library/Think/Controller.class.php
+++ b/ThinkPHP/Library/Think/Controller.class.php
@@ -226,6 +226,9 @@ abstract class Controller
      */
     protected function ajaxReturn($data, $type = '', $json_option = 0)
     {
+        // 调用 Hook
+        Hook::listen('ajax_return', $data);
+        
         if (empty($type)) {
             $type = C('DEFAULT_AJAX_RETURN');
         }
@@ -241,16 +244,16 @@ abstract class Controller
                 exit(xml_encode($data));
             case 'JSONP':
                 // 返回JSON数据格式到客户端 包含状态信息
-                header('Content-Type:application/json; charset=utf-8');
+                header('Content-Type:text/javascript; charset=utf-8');
                 $handler = isset($_GET[C('VAR_JSONP_HANDLER')]) ? $_GET[C('VAR_JSONP_HANDLER')] : C('DEFAULT_JSONP_HANDLER');
                 exit($handler . '(' . json_encode($data, $json_option) . ');');
             case 'EVAL':
                 // 返回可执行的js脚本
-                header('Content-Type:text/html; charset=utf-8');
+                header('Content-Type:text/javascript; charset=utf-8');
                 exit($data);
             default:
-                // 用于扩展其他返回格式数据
-                Hook::listen('ajax_return', $data);
+                header('Content-Type:text/plain; charset=utf-8');
+                exit($data);
         }
     }
 


### PR DESCRIPTION
这个 Hook 应该是任何时候都要被调用，而不是将 DEFAULT_AJAX_RETURN 配置成 xxx 才会调用。
另 JSONP 的本质是一段JS代码，Content-Type 应该是 text/javascript。
根据注释，EVAL 应该也是一段JS代码，同样 Content-Type 也应该是 text/javascript。
而 default 我个人认为 Content-Type 应该是 text/plain。

望采纳~