### PR TITLE
Update Db.class.php

### DIFF
--- a/ThinkPHP/Library/Think/Db.class.php
+++ b/ThinkPHP/Library/Think/Db.class.php
@@ -97,7 +97,7 @@ class Db
                 'rw_separate' => C('DB_RW_SEPARATE'),
                 'master_num'  => C('DB_MASTER_NUM'),
                 'slave_no'    => C('DB_SLAVE_NO'),
-                'debug'       => C('DB_DEBUG', null, APP_DEBUG),
+                'debug'       => C('DB_DEBUG') ? C('DB_DEBUG') : APP_DEBUG,
                 'lite'        => C('DB_LITE'),
             );
         }


### PR DESCRIPTION
配置文件的参数DB_DEBUG没有使用到,
'debug'         =>  isset($config['db_debug'])?$config['db_debug']:APP_DEBUG,
上边的if结构里却用到了,
然后导致在app_debug=true模式下程序会因为sql问题直接抛出异常.
