### PR TITLE
in_array不严谨问题

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -896,7 +896,7 @@ class Model {
             // 判断令牌验证字段
             if(C('TOKEN_ON'))   $fields[] = C('TOKEN_NAME');
             foreach ($data as $key=>$val){
-                if(!in_array($key,$fields)) {
+                if(!in_array($key,$fields,true)) {
                     unset($data[$key]);
                 }
             }


### PR DESCRIPTION
严谨性BUG 产生错误 字段为0时产生如$_REQUEST[0]='test' 入库时绕过校验并产生异常打印sql预计