### PR TITLE
修复setInc setDec无法处理与关键字重名的字段的bug

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -925,7 +925,7 @@ class Model
                 $step = '-' . $step;
             }
         }
-        return $this->setField($field, array('exp', $field . '+' . $step));
+        return $this->setField($field, array('exp', '`' . $field . '`+' . $step));
     }
 
     /**
@@ -949,7 +949,7 @@ class Model
                 $step = '-' . $step;
             }
         }
-        return $this->setField($field, array('exp', $field . '-' . $step));
+        return $this->setField($field, array('exp', '`' . $field . '`-' . $step));
     }
 
     /**


### PR DESCRIPTION
setfield时给field加上``

由于tp对set参数的处理很粗暴,等号后面是直接拼接传入的字符串的,只能从这里修复一下了。
不清楚是不是有数据库不支持真这种写法，不过从update中调用的prasekey的写法来看，似乎问题不大。 