### PR TITLE
两个小的修改，对debug比较有用

### DIFF
--- a/ThinkPHP/Lang/zh-cn.php
+++ b/ThinkPHP/Lang/zh-cn.php
@@ -28,6 +28,7 @@ return array(
     '_OPERATION_WRONG_'      => '操作出现错误',
     '_NOT_LOAD_DB_'          => '无法加载数据库',
     '_NO_DB_DRIVER_'         => '无法加载数据库驱动',
+    '_NO_DB_TYPE_'           => '没有加载数据库类型，请检查配置文件是否正确',
     '_NOT_SUPPORT_DB_'       => '系统暂时不支持数据库',
     '_NO_DB_CONFIG_'         => '没有定义数据库配置',
     '_NOT_SUPPORT_'          => '系统不支持',

--- a/ThinkPHP/Library/Think/Db.class.php
+++ b/ThinkPHP/Library/Think/Db.class.php
@@ -42,6 +42,8 @@ class Db
             $class = !empty($options['lite']) ? 'Think\Db\Lite' : 'Think\\Db\\Driver\\' . ucwords(strtolower($options['type']));
             if (class_exists($class)) {
                 self::$instance[$md5] = new $class($options);
+            } elseif (!($options['type'])) {
+                E(L('_NO_DB_TYPE_'));
             } else {
                 // 类没有定义
                 E(L('_NO_DB_DRIVER_') . ': ' . $class);

--- a/ThinkPHP/Library/Think/View.class.php
+++ b/ThinkPHP/Library/Think/View.class.php
@@ -91,6 +91,7 @@ class View
      */
     private function render($content, $charset = '', $contentType = '')
     {
+        static $hasSetHeader = false;
         if (empty($charset)) {
             $charset = C('DEFAULT_CHARSET');
         }
@@ -98,11 +99,14 @@ class View
         if (empty($contentType)) {
             $contentType = C('TMPL_CONTENT_TYPE');
         }
+        if(false === $hasSetHeader){
+            // 网页字符编码
+            header('Content-Type:' . $contentType . '; charset=' . $charset);
+            header('Cache-control: ' . C('HTTP_CACHE_CONTROL')); // 页面缓存控制
+            header('X-Powered-By:ThinkPHP');
+            $hasSetHeader = true;
+        }
 
-        // 网页字符编码
-        header('Content-Type:' . $contentType . '; charset=' . $charset);
-        header('Cache-control: ' . C('HTTP_CACHE_CONTROL')); // 页面缓存控制
-        header('X-Powered-By:ThinkPHP');
         // 输出模板文件
         echo $content;
     }


### PR DESCRIPTION
1. 

 当数据库配置有误(文件名/路径错误)时，new一个Model模型会报“无法加载数据库驱动:
Think\Db\Driver\”错误，一般人并不知道是因为数据库配置不当造成的,这里应该是Think\Db\Driver\DB_TYPE ,因为type为''所以显示是这样，所以想到修改一下错误提示为"加载数据库类型配置失败，请检查配置文件"

2. 

 如果一个方法里面多次$this->display()不同的部分页面内容时会报Warning:
Cannot modify header information - headers already sent by ...，为了消除这个警告，设置一个静态属性，这样第二次调用render方法时不会出现如上的警告了（对新手还是比较有用的，比如我）