### PR TITLE
修复事务bug

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver.class.php
@@ -303,7 +303,7 @@ abstract class Driver
                 return false;
             }
         } else {
-            $this->transTimes--;
+            $this->transTimes = $this->transTimes <= 0 ? 0 : $this->transTimes-1;
         }
         return true;
     }


### PR DESCRIPTION
修复：因为Model::startTrans()中调用了 Driver::commit() 方法，导致Dirver::$transTimes变成-1，从而导致 `$this->_linkID->beginTransaction()` 得不到执行，事务失效。
