### PR TITLE
修复$model->result方法不能正常工作

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -828,8 +828,8 @@ class Model
         // 读取数据后的处理
         $data = $this->_read_data($resultSet[0]);
         $this->_after_find($data, $options);
-        if (!empty($this->options['result'])) {
-            return $this->returnResult($data, $this->options['result']);
+        if (!empty($options['result'])) {
+            return $this->returnResult($data, $options['result']);
         }
         $this->data = $data;
         if (isset($cache)) {


### PR DESCRIPTION
$this->_parseOptions 后 $this->options 为空导致模型中的result 方法不能正常工作