### PR TITLE
支持复合查询or中有 like,in,gt这样的条件。

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver/Mongo.class.php
@@ -814,10 +814,10 @@ class Mongo extends Driver
                 break;
         }
         //兼容 MongoClient OR条件查询方法
-        if (isset($query['$or']) && !is_array(current($query['$or']))) {
+        if (isset($query['$or'])) {
             $val = array();
             foreach ($query['$or'] as $k => $v) {
-                $val[] = array($k => $v);
+                $val[] = $this->parseWhereItem($k,$v);
             }
 
             $query['$or'] = $val;


### PR DESCRIPTION
原来复合查询条件 or 只支持
$_map=array();
$_map['name'] = "lilei";
$_map['_logic'] = 'or';
不支持
$_map['name'] = array('like','lilei');或者 其它数组,加了以后可以支持。