### PR TITLE
修正addAll()的隐患bug

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver.class.php
@@ -967,9 +967,11 @@ abstract class Driver
                     }
                 }
             }
-            $values[] = 'SELECT ' . implode(',', $value);
+//            $values[] = 'SELECT ' . implode(',', $value);
+            $values[]    = '('.implode(',', $value).')';
         }
-        $sql = 'INSERT INTO ' . $this->parseTable($options['table']) . ' (' . implode(',', $fields) . ') ' . implode(' UNION ALL ', $values);
+        $sql   =  'INSERT INTO '.$this->parseTable($options['table']).' ('.implode(',', $fields).') values'.implode(',',$values);
+//        $sql = 'INSERT INTO ' . $this->parseTable($options['table']) . ' (' . implode(',', $fields) . ') ' . implode(' UNION ALL ', $values);
         $sql .= $this->parseComment(!empty($options['comment']) ? $options['comment'] : '');
         return $this->execute($sql, !empty($options['fetch_sql']) ? true : false);
     }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/8335926/18983485/a068cc5a-871f-11e6-9d17-4c2f80291f92.png)

- 描述：批量循环写入时，出现主键不连续的情况，跳跃增长（请自行测试）
- 紧急程度：严重
- 原因：innodb中insert操作分为三种情况：Simple inserts，Bulk inserts，Mixed-mode inserts，其中Simple inserts这种MySQL引擎提前知道要插入的行数，而后两种并不知道，针对三种情况mysql提供， innodb_autoinc_lock_mode 配置参数，设置为0，1（默认）或2，分别为 “ 传统的 ”，“ 连续的 ”， “ 交错 ”锁定模式。在官方默认的insert into table() (select *) union all (select *).... 属于Bulk inserts所以会造成主键不连续，反之insert into table() values(),().....属于Simple inserts则不会。除非手动修改innodb_autoinc_lock_mode=0，也就是采用传统锁模式，所有insert操作都要申请auto-inc锁。
- 文献：http://dev.mysql.com/doc/refman/5.5/en/innodb-auto-increment-handling.html
- PS：希望官方测试后，完善该BUG

