### PR TITLE
分页时只获取ACTION_NAME路径不全导致404 fixed

### DIFF
--- a/ThinkPHP/Library/Think/Page.class.php
+++ b/ThinkPHP/Library/Think/Page.class.php
@@ -85,7 +85,7 @@ class Page
 
         /* 生成URL */
         $this->parameter[$this->p] = '[PAGE]';
-        $this->url                 = U(ACTION_NAME, $this->parameter);
+        $this->url                 = U(MODULE_NAME.'/'.CONTROLLER_NAME.'/'.ACTION_NAME, $this->parameter);
         /* 计算分页信息 */
         $this->totalPages = ceil($this->totalRows / $this->listRows); //总页数
         if (!empty($this->totalPages) && $this->nowPage > $this->totalPages) {


### PR DESCRIPTION
当URL使用REWRITE模式，分页数字的链接缺少MODEL_NAME和CONTROLLER_NAME导致点击分页数字404.