### PR TITLE
修正了一处parse_str转换`.`为`_`的bug

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver.class.php
@@ -700,8 +700,17 @@ abstract class Driver
                 $whereStr = substr($this->parseWhere($val), 6);
                 break;
             case '_query':
+                $where = [];
                 // 字符串模式查询条件
-                parse_str($val, $where);
+                if (strpos($val, '.') === false)
+                    parse_str($val, $where);
+                else {
+                    $tmpWhere = explode('&', $val);
+                    foreach ($tmpWhere as $value) {
+                        $tmpValue            = explode('=', $value);
+                        $where[$tmpValue[0]] = $tmpValue[1];
+                    }
+                }
                 if (isset($where['_logic'])) {
                     $op = ' ' . strtoupper($where['_logic']) . ' ';
                     unset($where['_logic']);


### PR DESCRIPTION
当使用_query 方式作为where条件时,parse_str 对小数点转换导致使用alias()方法
具体例子
```
'_query' => 'goodsCatId1=442&goodsCatId2=442&goodsCatId3=442&_logic=or',
```
当使用alias后 
```
'_query' => 'g.goodsCatId1=442&g.goodsCatId2=442&g.goodsCatId3=442&_logic=or',
```
通过parse_str方法会被转换`.`为`_`
```
SELECT g.goodsId,g.goodsName,g.shopPrice,g.goodsThums,g.goodsUnit FROM tc_goods g WHERE g.goodsStatus = 1 AND g.goodsTag IN (0,1,2,3) AND g.brandId = 65 AND ( g_goodsCatId1 = '442' OR g_goodsCatId2 = '442' OR g_goodsCatId3 = '442' ) AND (  g.areaId1 = 370000 OR g.areaId2 = 370000 OR g.areaId3 = 370000 ) ORDER BY g.isAdminRecom DESC,g.createTime DESC LIMIT 0,2 
```
本次pr 在执行parse_str前对_query的值进行判断，如果其中有小数点，则使用 explode和foreach进行解析