### PR TITLE
改进事务方法，支持嵌套事务提交

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver.class.php
@@ -315,7 +315,7 @@ abstract class Driver
      */
     public function rollback()
     {
-        if ($this->transTimes > 0) {
+        if ($this->transTimes == 1) {
             $result = $this->_linkID->rollback();
             $this->transTimes = 0;
             $this->transPdo = null;
@@ -323,6 +323,8 @@ abstract class Driver
                 $this->error();
                 return false;
             }
+        } else {
+            $this->transTimes = $this->transTimes <= 0 ? 0 : $this->transTimes-1;
         }
         return true;
     }

--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -1673,7 +1673,6 @@ class Model
      */
     public function startTrans()
     {
-        $this->commit();
         $this->db->startTrans();
         return;
     }


### PR DESCRIPTION
原事务方法不支持如下写法

```
M()->startTrans();
M()->startTrans();
M()->rollback();//这行无效了
M()->commit();
M()->commit();

```

原因是 `Model::startTrans()` 方法会自动执行一次 `commit` ，这样会导致上面嵌套写法的事务在中间被强制提交 ，而之后的 `commit` 以及 `rollback` 全部无效，主要是rollback的失效会导致严重的问题。

为什么要嵌套事务：
不同的业务逻辑分散封装在不同的类里面，允许类方法内部开启事务，而不是依赖在最外层控制器中开启事务，事务真实提交应当由最后一次commit触发，而中间的rollback不受影响。

改进后的代码，移除了 `startTrans() ` 中的 `commit` ,修改 `Db\Driver` 里的 `commit`,`rollback`以及 'startTrans'，现在支持嵌套事务写法。