### PR TITLE
修复Model自动校验主键唯一Insert Bug

### DIFF
--- a/ThinkPHP/Library/Think/Model.class.php
+++ b/ThinkPHP/Library/Think/Model.class.php
@@ -1148,8 +1148,9 @@ class Model {
                 }else{
                     $map[$val[0]] = $data[$val[0]];
                 }
-                if(!empty($data[$this->getPk()])) { // 完善编辑的时候验证唯一
-                    $map[$this->getPk()] = array('neq',$data[$this->getPk()]);
+                $pk =   $this->getPk();
+                if(!empty($data[$pk]) && is_string($pk) && !(is_array($val[0])? in_array($pk, $val[0]) : $pk == $val[0])) { // 完善编辑的时候验证唯一
+                    $map[$pk] = array('neq',$data[$pk]);
                 }
                 if($this->where($map)->find())   return false;
                 return true;


### PR DESCRIPTION
当开发者将主键pk也写入validate时，程序会生成如下语句select * from table where id <> '{$id}' limit 1，即使设置了主键，这插入create校验时就已被拒绝，正确应为select * from table where id = '{$id}' limit 1，故修复BUG，加入判断当前pk是否等于当前传入key，是则不进行完善编辑的时候验证唯一。