### PR TITLE
[+] 添加自定义日志路径

### DIFF
--- a/ThinkPHP/Library/Think/App.class.php
+++ b/ThinkPHP/Library/Think/App.class.php
@@ -25,7 +25,11 @@ class App
     public static function init()
     {
         // 日志目录转换为绝对路径 默认情况下存储到公共模块下面
-        C('LOG_PATH', realpath(LOG_PATH) . '/Common/');
+        if (is_null(C('LOG_PATH'))) {
+            C('LOG_PATH', realpath(LOG_PATH) . '/Common/');
+        } else {
+            C('LOG_PATH', C('LOG_PATH') . '/Common/');
+        }
 
         // 定义当前请求的系统常量
         define('NOW_TIME', $_SERVER['REQUEST_TIME']);

--- a/ThinkPHP/Library/Think/Dispatcher.class.php
+++ b/ThinkPHP/Library/Think/Dispatcher.class.php
@@ -150,7 +150,7 @@ class Dispatcher
             // 定义当前模块的模版缓存路径
             C('CACHE_PATH', CACHE_PATH . MODULE_NAME . '/');
             // 定义当前模块的日志目录
-            C('LOG_PATH', realpath(LOG_PATH) . '/' . MODULE_NAME . '/');
+            C('LOG_PATH', C('LOG_PATH') . '/' . MODULE_NAME . '/');
 
             // 模块配置文件开始载入检测位
             Hook::listen('module_check');

--- a/ThinkPHP/Mode/Api/App.class.php
+++ b/ThinkPHP/Mode/Api/App.class.php
@@ -44,7 +44,11 @@ class App
         }
 
         // 日志目录转换为绝对路径
-        C('LOG_PATH', realpath(LOG_PATH) . '/');
+        if (is_null(C('LOG_PATH'))) {
+            C('LOG_PATH', realpath(LOG_PATH) . '/');
+        } else {
+            C('LOG_PATH', C('LOG_PATH') . '/');
+        }
         // TMPL_EXCEPTION_FILE 改为绝对地址
         C('TMPL_EXCEPTION_FILE', realpath(C('TMPL_EXCEPTION_FILE')));
         return;

--- a/ThinkPHP/Mode/Lite/App.class.php
+++ b/ThinkPHP/Mode/Lite/App.class.php
@@ -26,7 +26,11 @@ class App
     {
 
         // 日志目录转换为绝对路径 默认情况下存储到公共模块下面
-        C('LOG_PATH', realpath(LOG_PATH) . '/Common/');
+        if (is_null(C('LOG_PATH'))) {
+            C('LOG_PATH', realpath(LOG_PATH) . '/Common/');
+        } else {
+            C('LOG_PATH', C('LOG_PATH') . '/Common/');
+        }
 
         // 定义当前请求的系统常量
         define('NOW_TIME', $_SERVER['REQUEST_TIME']);

--- a/ThinkPHP/Mode/Lite/Dispatcher.class.php
+++ b/ThinkPHP/Mode/Lite/Dispatcher.class.php
@@ -154,7 +154,7 @@ class Dispatcher
             // 定义当前模块的模版缓存路径
             C('CACHE_PATH', CACHE_PATH . MODULE_NAME . '/');
             // 定义当前模块的日志目录
-            C('LOG_PATH', realpath(LOG_PATH) . '/' . MODULE_NAME . '/');
+            C('LOG_PATH', C('LOG_PATH') . '/' . MODULE_NAME . '/');
 
             // 加载模块配置文件
             if (is_file(MODULE_PATH . 'Conf/config' . CONF_EXT)) {


### PR DESCRIPTION
TP3.2的日志路径固定存放在了当前项目的Runtime目录中，有些不符合实际的情况，在实际线上环境中习惯于将所有项目日志存在一个固定的目录下，方便进行日志管理

[+] 用户配置 LOG_PATH ，则可以自定义日志路径，如果没有进行配置，则日志的存放路径默认还是当前项目的Runtime目录