### PR TITLE
修复fetchSql释放参数绑定

### DIFF
--- a/ThinkPHP/Library/Think/Db/Driver.class.php
+++ b/ThinkPHP/Library/Think/Db/Driver.class.php
@@ -220,6 +220,7 @@ abstract class Driver
             $this->queryStr = strtr($this->queryStr, array_map(function ($val) use ($that) {return '\'' . $that->escapeString($val) . '\'';}, $this->bind));
         }
         if ($fetchSql) {
+            $this->bind = array();
             return $this->queryStr;
         }
         //释放前次的查询结果


### PR DESCRIPTION
当通过fetchSql直接获取sql语句时，如果释放$this->bind，在执行另一个SQL如果有参数绑定会导致参数数量不匹配