### PR TITLE
修正路由

### DIFF
--- a/ThinkPHP/Library/Think/Dispatcher.class.php
+++ b/ThinkPHP/Library/Think/Dispatcher.class.php
@@ -76,7 +76,7 @@ class Dispatcher
                 $array = explode('/', $rule);
                 // 模块绑定
                 define('BIND_MODULE', array_shift($array));
-                // 控制器绑定         
+                // 控制器绑定
                 if (!empty($array)) {
                     $controller = array_shift($array);
                     if ($controller) {
@@ -268,10 +268,6 @@ class Dispatcher
         if (defined('BIND_CONTROLLER')) {
             return BIND_CONTROLLER;
         } else {
-            if ($paths && C('URL_ROUTER_ON') && Route::check($paths)) {
-                $depr = C('URL_PATHINFO_DEPR');
-                $paths = explode($depr, trim($_SERVER['PATH_INFO'], $depr));
-            }
             if ($paths) {
                 // PATH_INFO检测标签位
                 Hook::listen('path_info');

--- a/ThinkPHP/Library/Think/Route.class.php
+++ b/ThinkPHP/Library/Think/Route.class.php
@@ -272,9 +272,10 @@ class Route
                 }
             }
             // 动态路由
-            $result[1] = C('URL_ROUTE_RULES');
-            if (!empty($result[1])) {
-                foreach ($result[1] as $rule => $route) {
+            $result[1] = [];
+            $dynamicRoutes = C('URL_ROUTE_RULES');
+            if (!empty($dynamicRoutes)) {
+                foreach ($dynamicRoutes as $rule => $route) {
                     if (!is_array($route)) {
                         $route = array($route);
                     } elseif (is_numeric($rule)) {
@@ -348,8 +349,6 @@ class Route
                         }
                         $route[] = $args;
                         $result[1][$rule] = $route;
-                    } else {
-                        unset($result[1][$rule]);
                     }
                 }
             }

--- a/ThinkPHP/Library/Think/Route.class.php
+++ b/ThinkPHP/Library/Think/Route.class.php
@@ -58,7 +58,8 @@ class Route
                         continue;
                     }
                 }
-                if ($matches = self::checkUrlMatch($rule, $args, $regx)) {
+                $matches = self::checkUrlMatch($rule, $args, $regx);
+                if ($matches !== false) {
                     if ($route[0] instanceof \Closure) {
                         // 执行闭包
                         $result = self::invoke($route[0], $matches);

--- a/ThinkPHP/Library/Think/Route.class.php
+++ b/ThinkPHP/Library/Think/Route.class.php
@@ -437,7 +437,7 @@ class Route
                             }
                         } else {
                             // 如果值在排除的名单里
-                            if (in_array($var, $val[2])) {
+                            if (is_array($val[2]) && in_array($var, $val[2])) {
                                 return false;
                             }
                         }

--- a/ThinkPHP/Library/Think/Route.class.php
+++ b/ThinkPHP/Library/Think/Route.class.php
@@ -51,6 +51,10 @@ class Route
         // 动态路由检查
         if (!empty($rules[1])) {
             foreach ($rules[1] as $rule => $route) {
+                if (is_numeric($rule)) {
+                    $rule = array_shift($route);
+                }
+
                 $args = array_pop($route);
                 if (isset($route[2])) {
                     // 路由参数检查
@@ -147,6 +151,10 @@ class Route
         }
         if (isset($_rules[1][$path])) {
             foreach ($_rules[1][$path] as $rule => $route) {
+                if (is_numeric($rule)) {
+                    $rule = array_shift($route);
+                }
+
                 $args = array_pop($route);
                 $array = array();
                 if (isset($route[2])) {
@@ -275,7 +283,10 @@ class Route
             $result[1] = [];
             $dynamicRoutes = C('URL_ROUTE_RULES');
             if (!empty($dynamicRoutes)) {
-                foreach ($dynamicRoutes as $rule => $route) {
+                foreach ($dynamicRoutes as $key => $value) {
+                    $rule = $key;
+                    $route = $value;
+
                     if (!is_array($route)) {
                         $route = array($route);
                     } elseif (is_numeric($rule)) {
@@ -348,6 +359,13 @@ class Route
                             }
                         }
                         $route[] = $args;
+
+                        // 保持配置中路由定义的键的类型，以支持多个路由的路由表达式相同而路由参数不同的情况
+                        if (is_numeric($key)) {
+                            array_unshift($route, $rule);
+                            $rule = $key;
+                        }
+
                         $result[1][$rule] = $route;
                     }
                 }


### PR DESCRIPTION
- 严格检查`checkUrlMatch(...)`返回值为`false`才表示动态路由未匹配成功
- `ruleCache(...)`中读取路由配置应当避免改变路由定义顺序，因为顺序也会影响路由的解析
- 既然`Dispatcher`的`getModule(&$paths)`、`getController(&$paths, $urlCase)`和`getAction(&$paths, $urlCase)`方法把`&$paths`当做堆栈用，就不应该在堆栈中的数据处理完之前中途重置堆栈
- 用`ruleCache(...)`读取路由配置时，保持配置中路由定义的键的类型，以支持多个路由的路由表达式相同而路由参数不同的情况。在使用路由时，再处理键为整数索引的情况。